### PR TITLE
Removed 5 unnecessary stubbings in PerforceBlameCommandTest.java

### DIFF
--- a/src/test/java/org/sonar/plugins/scm/perforce/PerforceBlameCommandTest.java
+++ b/src/test/java/org/sonar/plugins/scm/perforce/PerforceBlameCommandTest.java
@@ -75,28 +75,23 @@ public class PerforceBlameCommandTest {
     // Changelist 3 is present in history
 
     IFileAnnotation line1ChangeList3 = mock(IFileAnnotation.class);
-    when(line1ChangeList3.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
     when(line1ChangeList3.getLower()).thenReturn(3);
 
     IFileAnnotation line2ChangeList3 = mock(IFileAnnotation.class);
-    when(line2ChangeList3.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
     when(line2ChangeList3.getLower()).thenReturn(3);
 
     // Changelist 4 is not present in history but can be fetched from server
 
     IFileAnnotation line3ChangeList4 = mock(IFileAnnotation.class);
-    when(line3ChangeList4.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
     when(line3ChangeList4.getLower()).thenReturn(4);
 
     // Changelist 5 is not present in history nor in server
 
     IFileAnnotation line4ChangeList5 = mock(IFileAnnotation.class);
-    when(line4ChangeList5.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
     when(line4ChangeList5.getLower()).thenReturn(5);
 
     // Put Changlist 4 again to verify we fetch only once from server
     IFileAnnotation line5ChangeList4 = mock(IFileAnnotation.class);
-    when(line5ChangeList4.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
     when(line5ChangeList4.getLower()).thenReturn(4);
 
     Map<IFileSpec, List<IFileRevisionData>> result = new HashMap<IFileSpec, List<IFileRevisionData>>();


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 5 stubbing are created in `PerforceBlameCommandTest.testBlameSubmittedFile` but never executed.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.